### PR TITLE
Fixes Earthdrive Animation

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -11328,8 +11328,7 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 
 	case LG_EARTHDRIVE: {
 			int32 dummy = 1;
-
-			clif_skill_damage( *src, *bl,tick, status_get_amotion(src), 0, -30000, 1, skill_id, skill_lv, DMG_SINGLE );
+			clif_skill_nodamage(src, *src, skill_id, skill_lv, 1);
 			i = skill_get_splash(skill_id,skill_lv);
 			map_foreachinallarea(skill_cell_overlap, src->m, src->x-i, src->y-i, src->x+i, src->y+i, BL_SKILL, LG_EARTHDRIVE, &dummy, src);
 			map_foreachinrange(skill_area_sub, bl,i,BL_CHAR,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);


### PR DESCRIPTION
its calling the wrong thing, causing the animation to not show up, this corrects it and causes the animation to be played properly when the skill is used.

also hurray for my first ever PR :D